### PR TITLE
Handle dashes in repo name and add underscore replacement logic

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/go-git/go-git/v5"
@@ -44,6 +45,11 @@ var (
 				return fmt.Errorf("import path must be in the form 'github.com/<user>/<app>'")
 			}
 			repoName := parts[2]
+			// reponame only have alphanumerics, dashes or underscores
+			if !regexp.MustCompile(`^[A-Za-z0-9_-]+$`).MatchString(repoName) {
+				return fmt.Errorf("repository name can only contain letters, numbers, dashes or underscores")
+			}
+			repoNameUnderscores := strings.ReplaceAll(repoName, "-", "_")
 
 			titleName, err := cmd.Flags().GetString("title-name")
 			if err != nil {
@@ -121,9 +127,7 @@ var (
 					return err
 				}
 
-				data = bytes.ReplaceAll(data, []byte("github.com/katabole/kbexample"), []byte(importPath))
-				data = bytes.ReplaceAll(data, []byte("KBExample"), []byte(titleName))
-				data = bytes.ReplaceAll(data, []byte("kbexample"), []byte(repoName))
+				data = applyReplacements(data, importPath, titleName, repoName, repoNameUnderscores)
 				if err := os.WriteFile(path, []byte(data), info.Mode()); err != nil {
 					return err
 				}
@@ -224,4 +228,13 @@ func checkApp(args string) error {
 		return err
 	}
 	return nil
+}
+
+// applyReplacements runs all of our placeholder swaps on the given content.
+func applyReplacements(content []byte, importPath, titleName, repoName, repoNameUnderscores string) []byte {
+	content = bytes.ReplaceAll(content, []byte("github.com/katabole/kbexample"), []byte(importPath))
+	content = bytes.ReplaceAll(content, []byte("KBExample"), []byte(titleName))
+	content = bytes.ReplaceAll(content, []byte("kb_example"), []byte(repoNameUnderscores))
+	content = bytes.ReplaceAll(content, []byte("kbexample"), []byte(repoName))
+	return content
 }

--- a/gen_test.go
+++ b/gen_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bytes"
+	"regexp"
+	"testing"
+)
+
+func TestApplyReplacements(t *testing.T) {
+	template := []byte(`
+import "github.com/katabole/kbexample"
+Title: KBExample
+psql -d kbexample_dev
+psql -d kb_example_dev
+`)
+
+	// 1) No-dash case: repoName == repoNameUnder, so we expect two identical replacements.
+	out := applyReplacements(template,
+		"github.com/foo/myapp", // importPath
+		"MyApp",                // titleName
+		"myapp",                // repoName
+		"myapp",                // repoNameUnderscores
+	)
+	count := bytes.Count(out, []byte("myapp_dev"))
+	if count != 2 {
+		t.Errorf("no-dash: expected 2 occurrences of \"myapp_dev\", got %d\nOutput:\n%s",
+			count, out)
+	}
+
+	// 2) With-dash case: expect one raw and one underscored
+	out = applyReplacements(template,
+		"github.com/foo/my-app",
+		"MyApp",
+		"my-app",
+		"my_app",
+	)
+	if c := bytes.Count(out, []byte("my-app_dev")); c != 1 {
+		t.Errorf("with-dash: expected 1 occurrence of \"my-app_dev\", got %d\nOutput:\n%s",
+			c, out)
+	}
+	if c := bytes.Count(out, []byte("my_app_dev")); c != 1 {
+		t.Errorf("with-dash: expected 1 occurrence of \"my_app_dev\", got %d\nOutput:\n%s",
+			c, out)
+	}
+}
+
+func TestRepoNameValidation(t *testing.T) {
+	re := regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+
+	valid := []string{"abc", "a_b-c", "A1_2-3"}
+	for _, s := range valid {
+		if !re.MatchString(s) {
+			t.Errorf("should be valid: %q", s)
+		}
+	}
+
+	invalid := []string{"bad$name", " space", "dot.name"}
+	for _, s := range invalid {
+		if re.MatchString(s) {
+			t.Errorf("should be invalid: %q", s)
+		}
+	}
+}


### PR DESCRIPTION
### Summary
This PR addresses an issue where using dashes in the import path causes generated psql commands in Taskfile.yml to fail. It:

- Validates that `repoName` only includes alphanumerics, dashes, or underscores
- Adds a `repoNameUnderscores` value for replacing `kb_example` placeholders
- Updates the template (kbexample/Taskfile.yml) to use `kb_example` in DB commands