### PR TITLE
Add happy‐path unit tests for katabole gen (kbexample + custom template repo)

### DIFF
--- a/gen.go
+++ b/gen.go
@@ -209,27 +209,27 @@ func checkNecessaryBinaries() error {
 
 	var result *multierror.Error
 
-	if err := checkApp("go version"); err != nil {
+	if err := checkApp("go", []string{"version"}); err != nil {
 		err = errors.New("go is not installed, to install it see https://go.dev/doc/install")
 		result = multierror.Append(result, err)
 	}
 
-	if err := checkApp("docker version"); err != nil {
+	if err := checkApp("docker", []string{"version"}); err != nil {
 		err = errors.New("docker is not installed, to install it see https://docs.docker.com/get-docker")
 		result = multierror.Append(result, err)
 	}
 
-	if err := checkApp("node -v"); err != nil {
+	if err := checkApp("node", []string{"-v"}); err != nil {
 		err = errors.New("node is not installed, to install it see  https://docs.npmjs.com/downloading-and-installing-node-js-and-npm")
 		result = multierror.Append(result, err)
 	}
 
-	if err := checkApp("psql -V"); err != nil {
+	if err := checkApp("psql", []string{"-V"}); err != nil {
 		err = errors.New("psql is not installed, to install it see https://www.postgresql.org/download")
 		result = multierror.Append(result, err)
 	}
 
-	if err := checkApp("task --version"); err != nil {
+	if err := checkApp("task", []string{"--version"}); err != nil {
 		err = errors.New("task is not installed, to install it see  https://taskfile.dev/installation")
 		result = multierror.Append(result, err)
 	}
@@ -238,8 +238,8 @@ func checkNecessaryBinaries() error {
 
 // checkApp looks for executables to run on user's local machine
 // and return nil if already installed and err otherwise
-func checkApp(args string) error {
-	cmd := exec.Command(args)
+func checkApp(name string, args []string) error {
+	cmd := exec.Command(name, args...)
 	if err := cmd.Run(); err != nil {
 		return err
 	}

--- a/gen_test.go
+++ b/gen_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package main
 
 import (
@@ -10,6 +12,18 @@ import (
 
 	"github.com/stretchr/testify/assert"
 )
+
+// skipIfMissingTools skips the test if any of the provided CLI tools are not
+// found on the host system. This prevents integration tests from failing on
+// minimal CI environments that lack Docker, Task, Node, etc.
+func skipIfMissingTools(t *testing.T, tools ...string) {
+	t.Helper()
+	for _, tool := range tools {
+		if _, err := exec.LookPath(tool); err != nil {
+			t.Skipf("skipping test – required tool %q not found", tool)
+		}
+	}
+}
 
 var kataboleBin string
 
@@ -98,6 +112,8 @@ func runCommand(dir, name string, args ...string) error {
 }
 
 func TestGenerateFromKbexample(t *testing.T) {
+	// Ensure required external tooling exists; otherwise skip.
+	skipIfMissingTools(t, "docker", "task", "npm", "npx")
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "kbexample")
 	defer runCommand(outputPath, "docker", "compose", "down")
@@ -148,6 +164,8 @@ func TestGenerateFromKbexample(t *testing.T) {
 // Happy-path flag tests for the katabole-gen-testing template
 
 func TestGenerateFromGenTesting_DefaultBranch(t *testing.T) {
+	// Integration test prerequisites
+	skipIfMissingTools(t, "git", "docker", "task")
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "test-output")
 
@@ -199,6 +217,8 @@ func TestGenerateFromGenTesting_Branch(t *testing.T) {
 }
 
 func TestGenerateFromGenTesting_Tag(t *testing.T) {
+	// Integration test prerequisites
+	skipIfMissingTools(t, "git", "docker", "task")
 	tmpDir := t.TempDir()
 	outputPath := filepath.Join(tmpDir, "test-output")
 


### PR DESCRIPTION
1. TestGenerateFromKbexample
        •	Clones the real github.com/katabole/kbexample repo
	•	Runs task setup and task test to verify end‐to‐end generation works

2. katabole-gen-testing (create an external repo)
	•	Contains minimal placeholder files with each of the four substitution patterns
	•	Has two branches (main, test-branch) and a tag (v0.1.0)

3. TestGenerateFromGenTesting_*
	•	DefaultBranch: clone & replace on the default (main) branch
	•	Branch: pass --template-ref test-branch and verify branch‐checkout replacement
	•	Tag: pass --template-ref v0.1.0 and verify tag‐checkout replacement
